### PR TITLE
Fix LinkedIn 404 and add Blog nav link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ author:
   social:
     github: skidder
     twitter: hexdumpster
-    linkedin: scott-kidder-2271041
+    linkedin: https://www.linkedin.com/in/scott-kidder-2271041/
 
 # Pagination
 paginate: 5

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,6 +1,4 @@
-- name: Home
+- name: Blog
   link: /
 - name: About
   link: /about
-- name: Sitemap
-  link: /sitemap


### PR DESCRIPTION
Two fixes:

**LinkedIn 404:** Hydejack was treating the username `scott-kidder-2271041` as a relative path and appending it to the current page URL. Changed to a full URL so the link icon goes to the correct LinkedIn profile regardless of what page you're on.

**Navigation:** Replaced Home/About/Sitemap with Blog/About. Blog links back to the post listing (`/`) from anywhere on the site, including from within a post.