### PR TITLE
Fix LinkedIn social link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ author:
   social:
     github: skidder
     twitter: hexdumpster
-    linkedin: https://www.linkedin.com/in/scott-kidder-2271041/
+    linkedin: scott-kidder-2271041
 
 # Pagination
 paginate: 5

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -1,0 +1,4 @@
+linkedin:
+  name: LinkedIn
+  icon: icon-linkedin
+  prepend: "https://www.linkedin.com/in/"


### PR DESCRIPTION
LinkedIn isn't a natively supported platform in Hydejack v9, so without a `_data/social.yml` entry the template was treating the username as a relative URL path, causing a 404.

Fix: adds `_data/social.yml` defining LinkedIn with its prepend URL and icon. Hydejack then constructs `https://www.linkedin.com/in/scott-kidder-2271041` correctly from the handle.