### PR TITLE
Fix LinkedIn icon: use inline SVG

### DIFF
--- a/_includes/components/social-list-item.html
+++ b/_includes/components/social-list-item.html
@@ -1,0 +1,46 @@
+{% assign platform = include.platform | downcase %}
+{% assign username = include.username %}
+
+{% if username.size > 0 %}
+  {% assign data_social = site.data.social[platform] %}
+
+  {% assign name = data_social.name | default:include.platform %}
+  {% assign icon = data_social.icon | default:'icon-link' %}
+  {% assign app = data_social.append %}
+  {% assign prep = data_social.prepend %}
+
+  {% unless data_social %}
+    {% if platform == "email" %}
+      {% assign name = "Email" %}
+      {% assign icon = "icon-mail" %}
+      {% assign prep = "mailto:" %}
+    {% elsif platform == "twitter" %}
+      {% assign name = "Twitter" %}
+      {% assign icon = "icon-twitter" %}
+      {% assign prep = "https://twitter.com/" %}
+    {% elsif platform == "github" %}
+      {% assign name = "GitHub" %}
+      {% assign icon = "icon-github" %}
+      {% assign prep = "https://github.com/" %}
+    {% endif %}
+  {% endunless %}
+
+  {% if username contains "//" or username contains "mailto:" %}
+    {% assign url = username %}
+  {% else %}
+    {% assign url = username | prepend:prep | append:app %}
+  {% endif %}
+
+  <li>
+    <a href="{{ url }}" title="{{ name }}" class="no-mark-external">
+      {% if platform == "linkedin" %}
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+        </svg>
+      {% else %}
+        <span class="{{ icon }}"></span>
+      {% endif %}
+      <span class="sr-only">{{ name }}</span>
+    </a>
+  </li>
+{% endif %}


### PR DESCRIPTION
Hydejack's icon font doesn't include a LinkedIn icon, so `icon-linkedin` renders as an empty box.

Fix: override `_includes/components/social-list-item.html` to render an inline SVG for LinkedIn specifically, while keeping the original icon-font path for all other platforms (GitHub, Twitter, email, etc.).