### PR TITLE
Fix sidebar nav links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,13 @@ hydejack:
     dynamic: true
     icon: true
 
+# Sidebar navigation
+menu:
+  - title: Blog
+    url:   /
+  - title: About
+    url:   /about/
+
 # Author
 author:
   name: Scott Kidder


### PR DESCRIPTION
Two fixes:

- **Sidebar links not showing:** Hydejack reads sidebar navigation from `menu:` in `_config.yml`, not `_data/navigation.yml`. Added a `menu:` block with Blog and About.
- **Blog link 404:** `/blog` doesn't exist - the post listing lives at `/`. Blog link now points to `/`.