### PR TITLE
Fix custom CSS injection via my-style.html include

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,8 +73,9 @@ plugins:
 github:
   repo: https://github.com/skidder/skidder.github.io
 
-# Custom styles
-google_fonts: false
+# Hydejack custom CSS (loaded automatically by the theme)
+hydejack:
+  custom_css: true
 
 # Sass
 sass:

--- a/_includes/my-style.html
+++ b/_includes/my-style.html
@@ -1,0 +1,41 @@
+<style>
+/* Post list separators */
+.list-lead + .list-group-item,
+.list-group-item + .list-group-item {
+  border-top: 1px solid rgba(var(--gray-bg), 0.15);
+  padding-top: 1.5rem;
+  margin-top: 0.5rem;
+}
+
+/* Better post date visibility */
+.faded,
+.list-group-item .faded,
+time {
+  opacity: 0.8;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+/* Continue reading link */
+.read-more,
+a.read-more {
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  border-bottom: 1.5px solid currentColor;
+  padding-bottom: 1px;
+}
+
+/* Sidebar text legibility over cover image */
+.sidebar-sticky .sidebar-about .sidebar-title,
+.sidebar-about h1 {
+  text-shadow: 0 1px 8px rgba(0,0,0,0.8);
+}
+
+.sidebar-sticky .sidebar-about .sidebar-tagline,
+.sidebar-about .sidebar-tagline {
+  text-shadow: 0 1px 5px rgba(0,0,0,0.7);
+}
+</style>


### PR DESCRIPTION
The previous approach (`_includes/my-head.html` + external `.scss` file) wasn't loading on GitHub Pages with `remote_theme`.

Hydejack v9 automatically checks for `_includes/my-style.html` and injects its contents into `<head>`. Using an inline `<style>` block here is the reliable pattern for remote_theme deployments.

Styles applied:
- Post list separators
- Better date visibility  
- Styled 'Continue reading' links
- Sidebar title/tagline text-shadow for legibility over cover image