### PR TITLE
Disable breadcrumbs to fix 404s on date archive pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ hydejack:
   no_large_headings: false
   no_structured_data: false
   no_theme_color: false
-  no_breadcrumbs: false
+  no_breadcrumbs: true
   use_lsi: false
   cookies_banner: false
   advertise: false


### PR DESCRIPTION
**Problem:** Clicking the breadcrumb nav at the top of posts (e.g. `home / 2026 / 03 / 30`) leads to 404s because GitHub Pages doesn't support the `jekyll-archives` plugin needed to generate year/month archive pages.

**Fix:** Set `no_breadcrumbs: true` in Hydejack config to hide the breadcrumb nav entirely.

**Broken URLs fixed:**
- `/2026/` → 404
- `/2026/03/` → 404  
- `/2026/03/30/` → 404
- `/2026/03/24/` → 404
- `/2017/` → 404 (etc.)