### PR TITLE
Rewrite about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -5,31 +5,16 @@ description: Engineering manager, distributed systems, video infrastructure.
 image: /public/apple-touch-icon-precomposed.png
 ---
 
-Hello, and welcome to my corner of the internet! I'm Scott Kidder, a technology enthusiast, software engineer, and lifelong learner.
+I'm Scott Kidder. I live in Benicia, CA and work as an Engineering Manager at [Discord](https://www.discord.com/), where my team handles all file-based media on the platform - uploads, processing, delivery, the whole stack.
 
-## Professional Background
+Before Discord I was at [Mux](https://www.mux.com/) as an early engineer, helping build the video and data products from scratch. Before that: [Brightcove](https://www.brightcove.com/), [Zencoder](https://www.brightcove.com/en/products/zencoder/), [MobiTV](https://en.wikipedia.org/wiki/MobiTV). Most of my career has been spent on video infrastructure in one form or another.
 
-I've been working in the tech industry for over 20 years, specializing in large scale distributed systems for video and media processing. Currently, I'm an Engineering Manager at [Discord](https://www.discord.com/), where I head the Media Infrastructure team responsible for handling all file-based UGC media on Discord.
-
-My journey in tech began in 1992 when I began developing small [TI-BASIC](https://en.wikipedia.org/wiki/TI-BASIC) programs for my TI-85. That kindled a passion for programming and Internet technologies. A few community college classes later, I was hooked, and went on to receive my Computer Science & Engineering degree at University of California, Davis.
-
-Since then, I've had the opportunity to contribute to numerous video services ([MobiTV](https://en.wikipedia.org/wiki/MobiTV), [Zencoder](https://www.brightcove.com/en/products/zencoder/), [Brightcove](https://www.brightcove.com/), [Mux](https://www.mux.com/), [Discord](https://www.discord.com/)), having the honor and pleasure to be an early engineer at Mux building the Mux Data & Video products from the ground up.
+I started programming on a TI-85 in 1992, picked up a CS degree from UC Davis, and haven't really stopped tinkering since.
 
 ## This Blog
 
-I started this blog as a way to share my thoughts, experiences, and learnings in the ever-evolving world of technology. Here, you'll find:
+Mostly a place to document things I've figured out - stuff I wish I'd found when I was searching for it. Hardware, home lab projects, distributed systems, whatever I happen to be working on.
 
-- Deep dives into interesting tech concepts
-- Tutorials and how-to guides
-- Reviews of tools and technologies I use
-- Reflections on industry trends and best practices
+## Outside Work
 
-## Beyond the Keyboard
-
-When I'm not coding or writing, you can find me camping (or curating my camping gear), hiking, or exploring new uses for LLMs.
-
-## Let's Connect
-
-I'm always excited to connect with fellow engineers and learners. Feel free to reach out on [LinkedIn](https://www.linkedin.com/in/scott-kidder-2271041/) or [GitHub](https://github.com/skidder).
-
-Thanks for stopping by!
+I backpack and camp with my son Ramsay when I can. I have a home network that has gotten somewhat out of hand.


### PR DESCRIPTION
Strips out the LinkedIn-resume tone. Short, direct, same voice as the posts.